### PR TITLE
add Gauss-Legendre quadrature rules for 1d, 2d and 3d

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,14 +11,38 @@ end
 
 ## Functions
 
-### Gauss-Legendre rules in 1d
+### Gauss-Legendre rules in segments
 
 ```@docs
-FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG1}}}
-FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG2}}}
-FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG3}}}
-FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG4}}}
-FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG5}}}
+FEMQuad.get_quadrature_points(::Type{Val{:GLSEG1}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLSEG2}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLSEG3}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLSEG4}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLSEG5}})
+```
+
+### Gauss-Legendre rules in quadrangles
+
+These rules are get from 1d quadratures by using tensor production
+
+```@docs
+FEMQuad.get_quadrature_points(::Type{Val{:GLQUAD1}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLQUAD4}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLQUAD9}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLQUAD16}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLQUAD25}})
+```
+
+### Gauss-Legendre rules in hexahedrons
+
+These rules are get from 1d quadratures by using tensor production
+
+```@docs
+FEMQuad.get_quadrature_points(::Type{Val{:GLHEX1}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLHEX8}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLHEX27}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLHEX81}})
+FEMQuad.get_quadrature_points(::Type{Val{:GLHEX243}})
 ```
 
 ## Index

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,9 +3,23 @@
 ```@contents
 ```
 
+```@meta
+DocTestSetup = quote
+    using FEMQuad
+end
+```
+
 ## Functions
 
-Add here.
+### Gauss-Legendre rules in 1d
+
+```@docs
+FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG1}}}
+FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG2}}}
+FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG3}}}
+FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG4}}}
+FEMQuad.get_integration_points :: Tuple{Type{Val{:GLSEG5}}}
+```
 
 ## Index
 

--- a/src/FEMQuad.jl
+++ b/src/FEMQuad.jl
@@ -2,5 +2,9 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
 
 module FEMQuad
-include("integrate.jl")
+
+# Gaussian-Legendre quadratures in one dimension
+include("glseg.jl")
+
+#include("integrate.jl")
 end

--- a/src/FEMQuad.jl
+++ b/src/FEMQuad.jl
@@ -3,8 +3,39 @@
 
 module FEMQuad
 
-# Gaussian-Legendre quadratures in one dimension
+# Gaussian-Legendre quadratures in 1d segments
 include("glseg.jl")
+# Gaussian-Legendre quadratures in 2d quadrangles
+include("glquad.jl")
+# Gaussian-Legendre quadratures in 3d hexahedrons
+include("glhex.jl")
 
 #include("integrate.jl")
+
+function get_rule(order::Int, rules::Vararg{Symbol})
+    for rule in rules
+        if get_order(Val{rule}) >= order
+            return rule
+        end
+    end
+end
+
+function integrate_1d(f::Function, rule::Symbol)
+    points = get_quadrature_points(Val{rule})
+    result = sum(w*f(ip) for (w, ip) in points)
+    return result
+end
+
+function integrate_2d(f::Function, rule::Symbol)
+    points = get_quadrature_points(Val{rule})
+    result = sum(w*f(ip) for (w, ip) in points)
+    return result
+end
+
+function integrate_3d(f::Function, rule::Symbol)
+    points = get_quadrature_points(Val{rule})
+    result = sum(w*f(ip) for (w, ip) in points)
+    return result
+end
+
 end

--- a/src/glhex.jl
+++ b/src/glhex.jl
@@ -1,0 +1,92 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
+
+### Gauss quadrature rules for hexahedrons using tensor products
+
+function tensor_product_3d(w::Tuple, p::Tuple)
+    N = length(w)
+    weights = Float64[]
+    points = Tuple{Float64, Float64, Float64}[]
+    for i in 1:N
+        for j in 1:N
+            for k in 1:N
+                push!(weights, w[i]*w[j]*w[k])
+                push!(points, (p[i], p[j], p[k]))
+            end
+        end
+    end
+    return zip(weights, points)
+end
+
+""" Gauss-Legendre quadrature, 1 point rule on hexahedron. """
+function get_quadrature_points(::Type{Val{:GLHEX1}})
+    w = (2.0, )
+    p = (0.0, )
+    return tensor_product_3d(w, p)
+end
+
+function get_order(::Type{Val{:GLHEX1}})
+    return 1
+end
+
+""" Gauss-Legendre quadrature, 8 point rule on hexahedron. """
+function get_quadrature_points(::Type{Val{:GLHEX8}})
+    w = (1.0, 1.0)
+    p = (-sqrt(1.0/3.0), sqrt(1.0/3.0))
+    return tensor_product_3d(w, p)
+end
+
+function get_order(::Type{Val{:GLHEX8}})
+    return 3
+end
+
+""" Gauss-Legendre quadrature, 27 point rule on hexahedron. """
+function get_quadrature_points(::Type{Val{:GLHEX27}})
+    w = (5.0/9.0, 8.0/9.0, 5.0/9.0)
+    p = (-sqrt(3.0/5.0), 0.0, sqrt(3.0/5.0))
+    return tensor_product_3d(w, p)
+end
+
+function get_order(::Type{Val{:GLHEX27}})
+    return 5
+end
+
+""" Gauss-Legendre quadrature, 81 point rule on hexahedron. """
+function get_quadrature_points(::Type{Val{:GLHEX81}})
+    w = (
+         1.0/36.0*(18.0-sqrt(30.0)),
+         1.0/36.0*(18.0+sqrt(30.0)),
+         1.0/36.0*(18.0+sqrt(30.0)),
+         1.0/36.0*(18.0-sqrt(30.0)))
+    p = (
+        -sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)),
+        -sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
+         sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
+         sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)))
+    return tensor_product_3d(w, p)
+end
+
+function get_order(::Type{Val{:GLHEX81}})
+    return 7
+end
+
+""" Gauss-Legendre quadrature, 243 point rule on quadrilateral. """
+function get_quadrature_points(::Type{Val{:GLHEX243}})
+    w = (
+        1.0/900.0*(322.0-13.0*sqrt(70.0)),
+        1.0/900.0*(322.0+13.0*sqrt(70.0)),
+        128.0/225.0,
+        1.0/900.0*(322.0+13.0*sqrt(70.0)),
+        1.0/900.0*(322.0-13.0*sqrt(70.0)))
+    p = (
+        -1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)),
+        -1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
+         0.0,
+         1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
+         1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)))
+    return tensor_product_3d(w, p)
+end
+
+function get_order(::Type{Val{:GLHEX243}})
+    return 9
+end

--- a/src/glquad.jl
+++ b/src/glquad.jl
@@ -1,0 +1,90 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
+
+### Gauss quadrature rules for quadrilaterals
+
+function tensor_product_2d(w::Tuple, p::Tuple)
+    N = length(w)
+    weights = Float64[]
+    points = Tuple{Float64, Float64}[]
+    for i in 1:N
+        for j in 1:N
+            push!(weights, w[i]*w[j])
+            push!(points, (p[i], p[j]))
+        end
+    end
+    return zip(weights, points)
+end
+
+""" Gauss-Legendre quadrature, 1 point rule on quadrilateral. """
+function get_quadrature_points(::Type{Val{:GLQUAD1}})
+    w = (2.0, )
+    p = (0.0, )
+    return tensor_product_2d(w, p)
+end
+
+function get_order(::Type{Val{:GLQUAD1}})
+    return 1
+end
+
+""" Gauss-Legendre quadrature, 4 point rule on quadrilateral. """
+function get_quadrature_points(::Type{Val{:GLQUAD4}})
+    w = (1.0, 1.0)
+    p = (-sqrt(1.0/3.0), sqrt(1.0/3.0))
+    return tensor_product_2d(w, p)
+end
+
+function get_order(::Type{Val{:GLQUAD4}})
+    return 3
+end
+
+""" Gauss-Legendre quadrature, 9 point rule on quadrilateral. """
+function get_quadrature_points(::Type{Val{:GLQUAD9}})
+    w = (5.0/9.0, 8.0/9.0, 5.0/9.0)
+    p = (-sqrt(3.0/5.0), 0.0, sqrt(3.0/5.0))
+    return tensor_product_2d(w, p)
+end
+
+function get_order(::Type{Val{:GLQUAD9}})
+    return 5
+end
+
+""" Gauss-Legendre quadrature, 16 point rule on quadrilateral. """
+function get_quadrature_points(::Type{Val{:GLQUAD16}})
+    w = (
+         1.0/36.0*(18.0-sqrt(30.0)),
+         1.0/36.0*(18.0+sqrt(30.0)),
+         1.0/36.0*(18.0+sqrt(30.0)),
+         1.0/36.0*(18.0-sqrt(30.0)))
+    p = (
+        -sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)),
+        -sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
+         sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
+         sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)))
+    return tensor_product_2d(w, p)
+end
+
+function get_order(::Type{Val{:GLQUAD16}})
+    return 7
+end
+
+""" Gauss-Legendre quadrature, 25 point rule on quadrilateral. """
+function get_quadrature_points(::Type{Val{:GLQUAD25}})
+    w = (
+        1.0/900.0*(322.0-13.0*sqrt(70.0)),
+        1.0/900.0*(322.0+13.0*sqrt(70.0)),
+        128.0/225.0,
+        1.0/900.0*(322.0+13.0*sqrt(70.0)),
+        1.0/900.0*(322.0-13.0*sqrt(70.0)))
+    p = (
+        -1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)),
+        -1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
+         0.0,
+         1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
+         1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)))
+    return tensor_product_2d(w, p)
+end
+
+function get_order(::Type{Val{:GLQUAD25}})
+    return 9
+end

--- a/src/glseg.jl
+++ b/src/glseg.jl
@@ -1,0 +1,64 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
+
+### Gauss quadrature rules for one dimension
+
+const GLSEG1 = Val{:GLSEG1}
+const GLSEG2 = Val{:GLSEG2}
+const GLSEG3 = Val{:GLSEG3}
+const GLSEG4 = Val{:GLSEG4}
+const GLSEG5 = Val{:GLSEG5}
+
+""" Gauss-Legendre quadrature, 1 point rule on segment. """
+function get_integration_points(::Type{GLSEG1})
+    weights = (2.0, )
+    points = (0.0, )
+    return zip(weights, points)
+end
+
+""" Gauss-Legendre quadrature, 2 point rule on segment. """
+function get_integration_points(::Type{GLSEG2})
+    weights = (1.0, 1.0)
+    points = (-sqrt(1.0/3.0), sqrt(1.0/3.0))
+    return zip(weights, points)
+end
+
+""" Gauss-Legendre quadrature, 3 point rule on segment. """
+function get_integration_points(::Type{GLSEG3})
+    weights = (5.0/9.0, 8.0/9.0, 5.0/9.0)
+    points = (-sqrt(3.0/5.0), 0.0, sqrt(3.0/5.0))
+    return zip(weights, points)
+end
+
+""" Gauss-Legendre quadrature, 4 point rule on segment. """
+function get_integration_points(::Type{GLSEG4})
+    weights = (
+               1.0/36.0*(18.0-sqrt(30.0)),
+               1.0/36.0*(18.0+sqrt(30.0)),
+               1.0/36.0*(18.0+sqrt(30.0)),
+               1.0/36.0*(18.0-sqrt(30.0)))
+    points = (
+        -sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)),
+        -sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
+         sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
+         sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)))
+    return zip(weights, points)
+end
+
+""" Gauss-Legendre quadrature, 5 point rule on segment. """
+function get_integration_points(::Type{GLSEG5})
+    weights = (
+        1.0/900.0*(322.0-13.0*sqrt(70.0)),
+        1.0/900.0*(322.0+13.0*sqrt(70.0)),
+        128.0/225.0,
+        1.0/900.0*(322.0+13.0*sqrt(70.0)),
+        1.0/900.0*(322.0-13.0*sqrt(70.0)))
+    points = (
+        -1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)),
+        -1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
+         0.0,
+         1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
+         1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)))
+    return zip(weights, points)
+end
+

--- a/src/glseg.jl
+++ b/src/glseg.jl
@@ -3,35 +3,41 @@
 
 ### Gauss quadrature rules for one dimension
 
-const GLSEG1 = Val{:GLSEG1}
-const GLSEG2 = Val{:GLSEG2}
-const GLSEG3 = Val{:GLSEG3}
-const GLSEG4 = Val{:GLSEG4}
-const GLSEG5 = Val{:GLSEG5}
-
 """ Gauss-Legendre quadrature, 1 point rule on segment. """
-function get_integration_points(::Type{GLSEG1})
+function get_quadrature_points(::Type{Val{:GLSEG1}})
     weights = (2.0, )
     points = (0.0, )
     return zip(weights, points)
 end
 
+function get_order(::Type{Val{:GLSEG1}})
+    return 1
+end
+
 """ Gauss-Legendre quadrature, 2 point rule on segment. """
-function get_integration_points(::Type{GLSEG2})
+function get_quadrature_points(::Type{Val{:GLSEG2}})
     weights = (1.0, 1.0)
     points = (-sqrt(1.0/3.0), sqrt(1.0/3.0))
     return zip(weights, points)
 end
 
+function get_order(::Type{Val{:GLSEG2}})
+    return 3
+end
+
 """ Gauss-Legendre quadrature, 3 point rule on segment. """
-function get_integration_points(::Type{GLSEG3})
+function get_quadrature_points(::Type{Val{:GLSEG3}})
     weights = (5.0/9.0, 8.0/9.0, 5.0/9.0)
     points = (-sqrt(3.0/5.0), 0.0, sqrt(3.0/5.0))
     return zip(weights, points)
 end
 
+function get_order(::Type{Val{:GLSEG3}})
+    return 5
+end
+
 """ Gauss-Legendre quadrature, 4 point rule on segment. """
-function get_integration_points(::Type{GLSEG4})
+function get_quadrature_points(::Type{Val{:GLSEG4}})
     weights = (
                1.0/36.0*(18.0-sqrt(30.0)),
                1.0/36.0*(18.0+sqrt(30.0)),
@@ -45,8 +51,12 @@ function get_integration_points(::Type{GLSEG4})
     return zip(weights, points)
 end
 
+function get_order(::Type{Val{:GLSEG4}})
+    return 7
+end
+
 """ Gauss-Legendre quadrature, 5 point rule on segment. """
-function get_integration_points(::Type{GLSEG5})
+function get_quadrature_points(::Type{Val{:GLSEG5}})
     weights = (
         1.0/900.0*(322.0-13.0*sqrt(70.0)),
         1.0/900.0*(322.0+13.0*sqrt(70.0)),
@@ -62,3 +72,6 @@ function get_integration_points(::Type{GLSEG5})
     return zip(weights, points)
 end
 
+function get_order(::Type{Val{:GLSEG5}})
+    return 9
+end

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -3,50 +3,6 @@
 
 # Let's drop here all integration schemes and some defaults for different element types maybe parse from txt file ..?
 
-### Gauss quadrature rules for one dimension
-
-function get_integration_points(::Type{Val{1}})
-    return [2.0], [0.0]
-end
-
-function get_integration_points(::Type{Val{2}})
-    return [1.0, 1.0], sqrt(1.0/3.0)*[-1.0, 1.0]
-end
-
-function get_integration_points(::Type{Val{3}})
-    return 1.0/9.0*[5.0, 8.0, 5.0], sqrt(3.0/5.0)*[-1.0, 0.0, 1.0]
-end
-
-function get_integration_points(::Type{Val{4}})
-    weights = 1.0/36.0*[
-        18.0-sqrt(30.0),
-        18.0+sqrt(30.0),
-        18.0+sqrt(30.0),
-        18.0-sqrt(30.0)]
-    points = [
-        -sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0)),
-        -sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
-         sqrt(3.0/7.0 - 2.0/7.0*sqrt(6.0/5.0)),
-         sqrt(3.0/7.0 + 2.0/7.0*sqrt(6.0/5.0))]
-    return weights, points
-end
-
-function get_integration_points(::Type{Val{5}})
-    weights = [
-        1.0/900.0*(322.0-13.0*sqrt(70.0)),
-        1.0/900.0*(322.0+13.0*sqrt(70.0)),
-        128.0/225.0,
-        1.0/900.0*(322.0+13.0*sqrt(70.0)),
-        1.0/900.0*(322.0-13.0*sqrt(70.0))]
-    points = [
-        -1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0)),
-        -1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
-         0.0,
-         1.0/3.0*sqrt(5.0 - 2.0*sqrt(10.0/7.0)),
-         1.0/3.0*sqrt(5.0 + 2.0*sqrt(10.0/7.0))]
-    return weights, points
-end
-
 function get_integration_points(order::Int64)
     if order <= 5
         return get_integration_points(Val{order})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,19 @@
 
 using Base.Test
 
+test_files = String[]
+
+push!(test_files, "glseg.jl")
+
+using TimerOutputs
+const to = TimerOutput()
 @testset "FEMQuad.jl" begin
-    @test 1 == 2
+    for fn in test_files
+        timeit(to, fn) do
+            include(fn)
+        end
+    end
 end
+println()
+println("Test statistics:")
+println(to)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,9 @@ using Base.Test
 
 test_files = String[]
 
-push!(test_files, "glseg.jl")
+push!(test_files, "test_glseg.jl")
+push!(test_files, "test_glquad.jl")
+push!(test_files, "test_glhex.jl")
 
 using TimerOutputs
 const to = TimerOutput()

--- a/test/test_glhex.jl
+++ b/test/test_glhex.jl
@@ -1,0 +1,23 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
+
+using Base.Test
+using FEMQuad
+using FEMQuad: integrate_3d, get_rule
+
+@testset "Gauss-Legendre quadratures in hexahedrons" begin
+    rules = (:GLHEX1, :GLHEX8, :GLHEX27, :GLHEX81, :GLHEX243)
+    f(i) = x -> sum(sum(x)^j for j=0:i)
+    r(i::Int) = get_rule(i, rules...)
+
+    @test isapprox(integrate_3d(f(0), r(0)), 8.0)
+    @test isapprox(integrate_3d(f(1), r(1)), 8.0)
+    @test isapprox(integrate_3d(f(2), r(2)), 16.0)
+    @test isapprox(integrate_3d(f(3), r(3)), 16.0)
+    @test isapprox(integrate_3d(f(4), r(4)), 184/5)
+    @test isapprox(integrate_3d(f(5), r(5)), 184/5)
+    @test isapprox(integrate_3d(f(6), r(6)), 12064/105)
+    @test isapprox(integrate_3d(f(7), r(7)), 12064/105)
+    @test isapprox(integrate_3d(f(8), r(8)), 9928/21)
+    @test isapprox(integrate_3d(f(9), r(9)), 9928/21)
+end

--- a/test/test_glquad.jl
+++ b/test/test_glquad.jl
@@ -1,0 +1,23 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
+
+using Base.Test
+using FEMQuad
+using FEMQuad: integrate_2d, get_rule
+
+@testset "Gauss-Legendre quadratures in quadrilaterals" begin
+    rules = (:GLQUAD1, :GLQUAD4, :GLQUAD9, :GLQUAD16, :GLQUAD25)
+    f(i) = x -> sum(sum(x)^j for j=0:i)
+    r(i::Int) = get_rule(i, rules...)
+
+    @test isapprox(integrate_2d(f(0), r(0)), 4.0)
+    @test isapprox(integrate_2d(f(1), r(1)), 4.0)
+    @test isapprox(integrate_2d(f(2), r(2)), 20/3)
+    @test isapprox(integrate_2d(f(3), r(3)), 20/3)
+    @test isapprox(integrate_2d(f(4), r(4)), 164/15)
+    @test isapprox(integrate_2d(f(5), r(5)), 164/15)
+    @test isapprox(integrate_2d(f(6), r(6)), 2108/105)
+    @test isapprox(integrate_2d(f(7), r(7)), 2108/105)
+    @test isapprox(integrate_2d(f(8), r(8)), 13492/315)
+    @test isapprox(integrate_2d(f(9), r(9)), 13492/315)
+end

--- a/test/test_glseg.jl
+++ b/test/test_glseg.jl
@@ -1,0 +1,35 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMQuad.jl/blob/master/LICENSE
+
+using Base.Test
+using FEMQuad
+
+function integrate_1d(f::Function, rule::Symbol)
+    points = FEMQuad.get_integration_points(getfield(FEMQuad, rule))
+    result = sum(w*f(ip) for (w, ip) in points)
+    return result
+end
+
+@testset "Gauss-Legendre quadratures in one dimension" begin
+    # Gaussian quadrature using N points can provide the exact integral if
+    # polynomial degree of f is 2N-1 or less => N = (deg(f)+1)/2
+
+    f1(x) = x   # N = 1
+    @test isapprox(integrate_1d(f1, :GLSEG1), 0.0)
+    f2(x) = x^2 # N = 1.5
+    @test isapprox(integrate_1d(f2, :GLSEG2), 2/3)
+    f3(x) = x^3 # N = 2
+    @test isapprox(integrate_1d(f3, :GLSEG2), 0.0)
+    f4(x) = x^4 # N = 2.5
+    @test isapprox(integrate_1d(f4, :GLSEG3), 2/5)
+    f5(x) = x^5 # N = 3
+    @test isapprox(integrate_1d(f5, :GLSEG3), 0.0)
+    f6(x) = x^6 # N = 3.5
+    @test isapprox(integrate_1d(f6, :GLSEG4), 2/7)
+    f7(x) = x^7 # N = 4
+    @test isapprox(integrate_1d(f7, :GLSEG4), 0.0)
+    f8(x) = x^8 # N = 4.5
+    @test isapprox(integrate_1d(f8, :GLSEG5), 2/9)
+    f9(x) = x^9 # N = 5
+    @test isapprox(integrate_1d(f9, :GLSEG5), 0.0)
+end

--- a/test/test_glseg.jl
+++ b/test/test_glseg.jl
@@ -3,33 +3,24 @@
 
 using Base.Test
 using FEMQuad
-
-function integrate_1d(f::Function, rule::Symbol)
-    points = FEMQuad.get_integration_points(getfield(FEMQuad, rule))
-    result = sum(w*f(ip) for (w, ip) in points)
-    return result
-end
+using FEMQuad: integrate_1d, get_rule
 
 @testset "Gauss-Legendre quadratures in one dimension" begin
     # Gaussian quadrature using N points can provide the exact integral if
     # polynomial degree of f is 2N-1 or less => N = (deg(f)+1)/2
 
-    f1(x) = x   # N = 1
-    @test isapprox(integrate_1d(f1, :GLSEG1), 0.0)
-    f2(x) = x^2 # N = 1.5
-    @test isapprox(integrate_1d(f2, :GLSEG2), 2/3)
-    f3(x) = x^3 # N = 2
-    @test isapprox(integrate_1d(f3, :GLSEG2), 0.0)
-    f4(x) = x^4 # N = 2.5
-    @test isapprox(integrate_1d(f4, :GLSEG3), 2/5)
-    f5(x) = x^5 # N = 3
-    @test isapprox(integrate_1d(f5, :GLSEG3), 0.0)
-    f6(x) = x^6 # N = 3.5
-    @test isapprox(integrate_1d(f6, :GLSEG4), 2/7)
-    f7(x) = x^7 # N = 4
-    @test isapprox(integrate_1d(f7, :GLSEG4), 0.0)
-    f8(x) = x^8 # N = 4.5
-    @test isapprox(integrate_1d(f8, :GLSEG5), 2/9)
-    f9(x) = x^9 # N = 5
-    @test isapprox(integrate_1d(f9, :GLSEG5), 0.0)
+    rules = (:GLSEG1, :GLSEG2, :GLSEG3, :GLSEG4, :GLSEG5)
+    f(i) = x -> sum([x^j for j=0:i])
+    r(i::Int) = get_rule(i, rules...)
+
+    @test isapprox(integrate_1d(f(0), r(0)), 2.0)
+    @test isapprox(integrate_1d(f(1), r(1)), 2.0)
+    @test isapprox(integrate_1d(f(2), r(2)), 8/3)
+    @test isapprox(integrate_1d(f(3), r(3)), 8/3)
+    @test isapprox(integrate_1d(f(4), r(4)), 46/15)
+    @test isapprox(integrate_1d(f(5), r(5)), 46/15)
+    @test isapprox(integrate_1d(f(6), r(6)), 352/105)
+    @test isapprox(integrate_1d(f(7), r(7)), 352/105)
+    @test isapprox(integrate_1d(f(8), r(8)), 1126/315)
+    @test isapprox(integrate_1d(f(9), r(9)), 1126/315)
 end


### PR DESCRIPTION
2d and 3d are made using tensor products, tetrahedron rules still needs to be implemented.